### PR TITLE
темы\стили в вики, кроме swamp

### DIFF
--- a/jamwiki-core/src/main/java/org/jamwiki/db/AnsiQueryHandler.java
+++ b/jamwiki-core/src/main/java/org/jamwiki/db/AnsiQueryHandler.java
@@ -1603,6 +1603,7 @@ public class AnsiQueryHandler implements QueryHandler {
 		user.setEmail(rs.getString("email"));
 		user.setEditor(rs.getString("editor"));
 		user.setSignature(rs.getString("signature"));
+    user.setStyle(rs.getString("style"));
 		return user;
 	}
 

--- a/jamwiki-core/src/main/java/org/jamwiki/model/WikiUser.java
+++ b/jamwiki-core/src/main/java/org/jamwiki/model/WikiUser.java
@@ -42,6 +42,7 @@ public class WikiUser implements Serializable {
 	private String signature = null;
 	private String username = null;
 	private int userId = -1;
+  private String style = "tango";
 
 	/**
 	 *
@@ -202,4 +203,12 @@ public class WikiUser implements Serializable {
 	public String getUsername() {
 		return username;
 	}
+
+  public String getStyle() {
+    return style;
+  }
+
+  public void setStyle(String style1) {
+    style = style1;
+  }
 }

--- a/jamwiki-war/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/jamwiki-war/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -41,7 +41,7 @@
 		<intercept-url pattern="/**/Special:Upgrade" access="ROLE_SYSADMIN" />
 		<intercept-url pattern="/**/Special:VirtualWiki" access="ROLE_SYSADMIN" />
 		<intercept-url pattern="/**/*.jsp" filters="none" />
-		<intercept-url pattern="/**/*.css" filters="none" />
+		<intercept-url pattern="/**/*.css" access="ROLE_VIEW" />
 		<intercept-url pattern="/images/**" filters="none" />
 		<intercept-url pattern="/js/**" filters="none" />
 		<intercept-url pattern="/upload/**" filters="none" />

--- a/jamwiki-web/src/main/java/org/jamwiki/servlets/StylesheetServlet.java
+++ b/jamwiki-web/src/main/java/org/jamwiki/servlets/StylesheetServlet.java
@@ -16,12 +16,20 @@
  */
 package org.jamwiki.servlets;
 
-import java.io.PrintWriter;
+import java.io.*;
+import java.util.Properties;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringUtils;
+import org.jamwiki.Environment;
 import org.jamwiki.WikiBase;
+import org.jamwiki.authentication.WikiUserDetailsImpl;
+import org.jamwiki.model.WikiUser;
 import org.jamwiki.utils.WikiLogger;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.servlet.ModelAndView;
+import sun.nio.ch.FileKey;
 
 /**
  * Used to generate the jamwiki.css stylesheet.
@@ -35,7 +43,10 @@ public class StylesheetServlet extends JAMWikiServlet {
 	 */
 	protected ModelAndView handleJAMWikiRequest(HttpServletRequest request, HttpServletResponse response, ModelAndView next, WikiPageInfo pageInfo) throws Exception {
 		String virtualWiki = pageInfo.getVirtualWikiName();
-		String stylesheet = ServletUtil.cachedContent(request.getContextPath(), request.getLocale(), virtualWiki, WikiBase.SPECIAL_PAGE_STYLESHEET, false);
+    String username = StringUtils.trim(request.getParameter("user"));
+    WikiUser user = ServletUtil.currentWikiUser();
+    String styleLink = WikiBase.SPECIAL_PAGE_STYLESHEET + ':' + user.getStyle();
+		String stylesheet = ServletUtil.cachedContent(request.getContextPath(), request.getLocale(), virtualWiki, styleLink, false);
 		response.setContentType("text/css");
 		response.setCharacterEncoding("UTF-8");
 		// cache for 30 minutes (60 * 30 = 1800)


### PR DESCRIPTION
в базе:

```
CREATE OR REPLACE VIEW jam_wiki_user AS
     SELECT users.id AS wiki_user_id, users.nick AS login, users.name AS display_name, users.regdate AS create_date, users.lastlogin AS last_login_date, '127.0.0.1'::character varying(15) AS create_ip_address, '127.0.0.1'::character varying(15) AS last_login_ip_address, 'ru_RU'::character varying(8) AS default_locale, users.email, 'toolbar'::character varying(50) AS editor, ''::character varying(255) AS signature, style FROM users;
```

перед установкой в вики создаем странички
- StyleSheet:tango
- StyleSheet:black
- StyleSheet:white2
- StyleSheet:white

внедряем туда данные из StyleSheet, в `Управление` каждой странички ставим галочку `Только для администрации`

в black можно внедрить то, что сделал @moscwich https://www.linux.org.ru/forum/lor-source/6976730?cid=6991185
